### PR TITLE
(+) Animal Owners and Caretakers now show up listed

### DIFF
--- a/src/components/animals/Animal.js
+++ b/src/components/animals/Animal.js
@@ -84,13 +84,17 @@ export const Animal = ({ animal, syncAnimals,
                         <section>
                             <h6>Caretaker(s)</h6>
                             <span className="small">
-                                Unknown
+                                {
+                                    currentAnimal.animalCaretakers?.map(a => a.user.name + " ")
+                                }
                             </span>
 
 
                             <h6>Owners</h6>
                             <span className="small">
-                                Owned by unknown
+                                {
+                                    currentAnimal.animalOwners?.map(a => a.user.name + " ")
+                                }
                             </span>
 
                             {


### PR DESCRIPTION
#### Changes Made

1. Modified Animal to show Caretakers and Owners through a map.
   

#### Steps to Review

1. Checkout this branch locally.
   ```
   git fetch --all
   git checkout branchname
   ```
2. Open a new Terminal tab (⌘T) and navigate to the server directory.
3. Test app functionality.
   > When user selects an animal from AnimalList, the detailed view will list caretaker and owner names.